### PR TITLE
Fixes date parsing on Safari

### DIFF
--- a/ts/charts.ts
+++ b/ts/charts.ts
@@ -1,7 +1,7 @@
 import * as Highcharts from 'highcharts';
 import * as HighchartsMore from "highcharts/highcharts-more";
 import {Controls} from "./controls";
-import {dateRange} from "./date";
+import {dateRange, db2Date} from "./date";
 import {COLORS, VECTOR_OPACITY} from "./color";
 import {OlObjects, getPrecision} from "./ol";
 import Feature from "ol/Feature";
@@ -520,7 +520,7 @@ function initCharts(controls: Controls): Charts {
  */
 function calculateTimelineEvent(features: Feature[], charts: Charts, controls: Controls) {
     features.forEach((feature) => {
-        let date = new Date(feature.get('skredTidspunkt'));
+        let date = db2Date(feature.get('skredTidspunkt'));
         date.setHours(0, 0, 0, 0);
         let dateStart = new Date(controls.dateStart.value);
         let offset = Math.round((date.getTime() - dateStart.getTime()) / (1000 * 3600 * 24));
@@ -539,7 +539,7 @@ function calculateTimelineEvent(features: Feature[], charts: Charts, controls: C
  */
 function calculateTimelineCluster(features: Feature[], charts: Charts, controls: Controls) {
     features.forEach((feature) => {
-        let date = new Date(feature.get('skredTidspunkt'));
+        let date = db2Date(feature.get('skredTidspunkt'));
         date.setHours(0, 0, 0, 0);
         let dateStart = new Date(controls.dateStart.value);
         let offset = Math.round((date.getTime() - dateStart.getTime()) / (1000 * 3600 * 24));

--- a/ts/date.ts
+++ b/ts/date.ts
@@ -15,6 +15,22 @@ const TIME_FORMAT = {
 };
 
 /**
+ * Creates a Date from datestring from database.
+ * @param date: yyyy-mm-dd hh-MM-ss.xxxxxx
+ * @return Date
+ */
+function db2Date(dateString: string): Date {
+    // Safari is picky about date parsing
+    let year = parseInt(dateString.slice(0, 4), 10);
+    let month = parseInt(dateString.slice(5, 7), 10) - 1;
+    let day = parseInt(dateString.slice(8, 10), 10);
+    let hour = parseInt(dateString.slice(11, 13), 10);
+    let minute = parseInt(dateString.slice(14, 16), 10);
+    let second = parseInt(dateString.slice(17, 19), 10);
+    return new Date(year, month, day, hour, minute, second)
+}
+
+/**
  * Transforms Date to datestring of format yyyy-mm-dd
  * @param date: Date
  * @return string - yyyy-mm-dd
@@ -38,4 +54,4 @@ function dateRange(start: Date, end: Date): string[] {
     return range.map((date) => getDate(date));
 }
 
-export {DATE_FORMAT, TIME_FORMAT, dateRange, getDate};
+export {DATE_FORMAT, TIME_FORMAT, dateRange, getDate, db2Date};

--- a/ts/main.ts
+++ b/ts/main.ts
@@ -32,7 +32,6 @@ document.addEventListener('DOMContentLoaded', () => {
     Charts.clearStatistics(false, charts, controls);
     Ol.getCluster(ol, controls, clusterClosure);
     Ol.getEvents(ol, controls, eventClosure);
-
     let dateChangeClosure = () => {
         Popup.setPopup(undefined, null, ol);
         Controls.showEmptyBox(false);

--- a/ts/ol.ts
+++ b/ts/ol.ts
@@ -562,7 +562,7 @@ function filterArrayByRegions_(array: Feature[], keep: boolean, controls: Contro
             } else if (!keep && storedNotRegion && storedNotRegion.indexOf(name) != -1) {
                 return feature;
             } else if (!storedNotRegion || storedNotRegion.indexOf(name) == -1) {
-                let date = getDate(new Date(db2Date(feature.get("skredTidspunkt"))));
+                let date = getDate(db2Date(feature.get("skredTidspunkt")));
                 let id = feature.get("skredID");
                 let evalFeature = feature;
                 if (date in ol.clustersByDate && id in ol.clustersByDate[date]) {

--- a/ts/ol.ts
+++ b/ts/ol.ts
@@ -1,5 +1,5 @@
 import {addRegion, Controls} from "./controls";
-import {dateRange, getDate} from "./date";
+import {dateRange, getDate, db2Date} from "./date";
 import {get} from "./network";
 import * as Cookie from "./cookie";
 import * as Layer from "./ol/layer";
@@ -330,7 +330,7 @@ function resetVectors(skipDates: boolean, skipRegions: boolean, ol: OlObjects, c
         }
         let featuresToRemove = filterArrayByRegions_(features, false, controls, ol);
         featuresToRemove.forEach((feature) => {
-            let date = getDate(new Date(feature.get("skredTidspunkt")));
+            let date = getDate(db2Date(feature.get("skredTidspunkt")));
             let id = feature.get("skredID");
             delete ol.clustersByDate[date][id];
             if (!Object.keys(ol.clustersByDate[date]).length) delete ol.clustersByDate[date];
@@ -456,7 +456,7 @@ function getVector_(
 
         let geoJson = new GeoJSON();
         json.features.forEach((geoJsonFeature: GeoJSONFeature) => {
-            let dateString = getDate(new Date(geoJsonFeature.properties.skredTidspunkt));
+            let dateString = getDate(db2Date(geoJsonFeature.properties.skredTidspunkt));
             let id = geoJsonFeature.properties.skredID;
             let exists = existMap[dateString] && existMap[dateString][geoJsonFeature.properties.skredID];
             if (!exists) {
@@ -516,7 +516,7 @@ function filter_(
 ) {
     let filtered = filterArrayByRegions_(newEvents, true, controls, ol);
     filtered.forEach((feature) => {
-        let dateString = getDate(new Date(feature.get("skredTidspunkt")));
+        let dateString = getDate(db2Date(feature.get("skredTidspunkt")));
         if (!(dateString in existMap)) existMap[dateString] = {};
         existMap[dateString][feature.get("skredID")] = feature;
     });
@@ -562,7 +562,7 @@ function filterArrayByRegions_(array: Feature[], keep: boolean, controls: Contro
             } else if (!keep && storedNotRegion && storedNotRegion.indexOf(name) != -1) {
                 return feature;
             } else if (!storedNotRegion || storedNotRegion.indexOf(name) == -1) {
-                let date = getDate(new Date(feature.get("skredTidspunkt")));
+                let date = getDate(new Date(db2Date(feature.get("skredTidspunkt"))));
                 let id = feature.get("skredID");
                 let evalFeature = feature;
                 if (date in ol.clustersByDate && id in ol.clustersByDate[date]) {

--- a/ts/ol/popup.ts
+++ b/ts/ol/popup.ts
@@ -1,5 +1,5 @@
 import {OlObjects} from "../ol";
-import {TIME_FORMAT} from "../date";
+import {TIME_FORMAT, db2Date} from "../date";
 import Feature from "ol/Feature";
 import {Coordinate} from "ol/coordinate";
 import Overlay from "ol/Overlay";
@@ -55,15 +55,15 @@ function formatEventInfo_(event: Feature): HTMLDivElement {
     } as Record<string, string>)[dbText];
 
     let avalId = event.get("skredID");
-    let avalDate = event.get("skredTidspunkt");
+    let avalDate = db2Date(event.get("skredTidspunkt"));
     let precAvalDate = event.get("noySkredTidspunkt");
     let aspect = parseInt(event.get("eksposisjonUtlopsomr"), 10);
     let area = Math.round(event.get("area")).toLocaleString("no-NO");
     let stopHeight = Math.round(event.get("hoydeStoppSkred_moh")).toLocaleString("no-NO");
     let precStopHeight = event.get("noyHoydeStoppSkred");
     let regStatus = event.get("regStatus");
-    let regDate = event.get("registrertDato");
-    let changeDate = event.get("endretDato");
+    let regDate = db2Date(event.get("registrertDato"));
+    let changeDate = db2Date(event.get("endretDato"));
     let meanSlope = Math.round(event.get("snittHelningUtlopssomr_gr")).toLocaleString("no-NO");
     let minSlope = Math.round(event.get("minHelningUtlopsomr_gr")).toLocaleString("no-NO");
     let maxSlope = Math.round(event.get("maksHelningUtlopsomr_gr")).toLocaleString("no-NO");
@@ -72,7 +72,7 @@ function formatEventInfo_(event: Feature): HTMLDivElement {
 
     if (avalId) htmlText.push(["Avalanche ID:", avalId]);
     if (avalDate) {
-        let dateString = new Date(avalDate).toLocaleDateString("no-NO", TIME_FORMAT);
+        let dateString = avalDate.toLocaleDateString("no-NO", TIME_FORMAT);
         if (precAvalDate) dateString += ` ± ${precision(precAvalDate)}&nbsph`;
         htmlText.push(["Triggered:", dateString]);
     }
@@ -89,11 +89,11 @@ function formatEventInfo_(event: Feature): HTMLDivElement {
     }
     if (regStatus) htmlText.push(["Registration:", status(regStatus)]);
     if (regDate) {
-        let dateString = new Date(regDate).toLocaleDateString("no-NO", TIME_FORMAT);
+        let dateString = regDate.toLocaleDateString("no-NO", TIME_FORMAT);
         htmlText.push(["Registered:", dateString]);
     }
     if (changeDate && regDate != changeDate) {
-        let dateString = new Date(changeDate).toLocaleDateString("no-NO", TIME_FORMAT);
+        let dateString = changeDate.toLocaleDateString("no-NO", TIME_FORMAT);
         htmlText.push(["Last edited:", dateString]);
     }
 


### PR DESCRIPTION
Date.parse() is implementation-dependent and dangerous
to use. It failed silently on Safari on all dates returned
from the database.

A new custom function for parsing dates from the database has
been added to mitigate this.